### PR TITLE
remove namespace and username params from origin query URL (PROJQUAY-5939)

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ async function handleRequest(request) {
   url.searchParams.delete('cf_expiry')
   url.searchParams.delete('cf_sign')
   url.searchParams.delete('region')
+  url.searchParams.delete('namespace')
+  url.searchParams.delete('username')
   url.host = s3Host;
 
   const fetchUrl = url.toString();


### PR DESCRIPTION
We don't want to pass the namespace and username to the origin as they are not part of the presigned S3 URL